### PR TITLE
Fixed links in writer.go

### DIFF
--- a/context/writer.go
+++ b/context/writer.go
@@ -555,10 +555,10 @@ func (w *Writer) WriteInlines(ll pandoc.InlineList) {
 
 				w.wr("\\goto{")
 				w.WriteInlines(l.Content)
-				w.wr("}[")
+				w.wr("}[url(")
 				s := strings.TrimPrefix(l.Target.URL, "#")
 				w.wr(s)
-				w.wr(("]"))
+				w.wr((")]"))
 			}
 
 			// todo Link, Cite, Span


### PR DESCRIPTION
The only thing that needed to be fixed was in `WriteInlines` in `writer.go`, the form behind the `\goto` command is as follows: `\goto{some text that's awesome}[url(https://some.url)]` but the code originally didn't have the `url(...)` part.